### PR TITLE
Augment to Derive, dropping exponentiation

### DIFF
--- a/draft-amjad-cfrg-partially-blind-rsa.md
+++ b/draft-amjad-cfrg-partially-blind-rsa.md
@@ -46,18 +46,18 @@ It is an extension to the RSABSSA protocol recently specified by the CFRG.
 {{?RSABSSA=I-D.irtf-cfrg-rsa-blind-signatures}} specifies the RSA blind
 signature protocol, denoted RSABSSA. This is a two-party protocol between
 client and server (or signer) where they interact to compute
-`sig = Sign(skS, input_msg)`, where `input_msg = Prepare(msg)` is a prepared
-version of the private message `msg` provided by the client, and `skS` is
+`sig = Sign(sk, input_msg)`, where `input_msg = Prepare(msg)` is a prepared
+version of the private message `msg` provided by the client, and `sk` is
 the signing key provided by the server. Upon completion of this protocol,
 the server learns nothing, whereas the client learns `sig`. In particular,
 this means the server learns nothing of `msg` or `input_msg` and the client
-learns nothing of `skS`.
+learns nothing of `sk`.
 
 RSABSSA has a variety of applications, with {{?PRIVACY-PASS=I-D.ietf-privacypass-protocol}}
 being a canonical example. While useful, this protocol is limited in that
 it does not easily accommodate public metadata to be associated with
 a (message, signature) pair. In this context, public metadata is information
-that's publicly known to both client and server at the time of computation.
+that is publicly known to both client and server at the time of computation.
 This has useful applications in practice. For example, metadata might be used
 to encode expiration information for a (message, signature) pair. In practice,
 metadata can be encoded using signing key pairs, e.g., by associating one
@@ -98,10 +98,10 @@ in this document:
 
 # RSAPBSSA Protocol {#core-protocol}
 
-The RSAPBSSA protocol consists of two helper functions -- AugmentPrivateKey and AugmentPublicKey -- and
+The RSAPBSSA protocol consists of two helper functions -- DeriveKeyPair and DerivePublicKey -- and
 four core functions -- Prepare, Blind, BlindSign, and Finalize -- and requires one
 round of interaction between client and server. Let `msg` be the client's private input
-message, `info` be the public metadata shared between client and server, and `(skS, pkS)`
+message, `info` be the public metadata shared between client and server, and `(sk, pk)`
 be the server's private and public key pair. The REQUIRED key generation procedure for RSAPBSSA
 is specified in {{key-generation}}.
 
@@ -114,45 +114,45 @@ input_msg = Prepare(msg)
 The client then initiates the blind signature protocol by computing:
 
 ~~~
-blinded_msg, inv = Blind(pkS, input_msg, info)
+blinded_msg, inv = Blind(pk, input_msg, info)
 ~~~
 
 The client then sends `blinded_msg` to the server, which then processes the message
 by computing:
 
 ~~~
-blind_sig = BlindSign(skS, blinded_msg, info)
+blind_sig = BlindSign(sk, blinded_msg, info)
 ~~~
 
 The server then sends `blind_sig` to the client, which then finalizes the protocol by computing:
 
 ~~~
-sig = Finalize(pkS, input_msg, info, blind_sig, inv)
+sig = Finalize(pk, input_msg, info, blind_sig, inv)
 ~~~
 
 The output of the protocol is `input_msg` and `sig`. Upon completion, correctness requires that
-clients can verify signature `sig` over the prepared message `input_msg` and metadata `metadata`
-using the server public key `pkS` by invoking the RSASSA-PSS-VERIFY routine defined in
+clients can verify signature `sig` over the prepared message `input_msg` and metadata `info`
+using the server public key `pk` by invoking the RSASSA-PSS-VERIFY routine defined in
 {{Section 8.1.2 of !RFC8017}}. The Finalize function performs this check before returning the signature.
 See {{verification}} for more details about verifying signatures produced through this protocol.
 
 In pictures, the protocol runs as follows:
 
 ~~~
-   Client(pkS, msg, metadata)          Server(skS, pkS, metadata)
+   Client(pk, msg, info)          Server(sk, pk, info)
   -------------------------------------------------------
   input_msg = Prepare(msg)
-  blinded_msg, inv = Blind(pkS, input_msg, metadata)
+  blinded_msg, inv = Blind(pk, input_msg, info)
 
                         blinded_msg
                         ---------->
 
-            blind_sig = BlindSign(skS, blinded_msg, metadata)
+            blind_sig = BlindSign(sk, blinded_msg, info)
 
                          blind_sig
                         <----------
 
-  sig = Finalize(pkS, input_msg, metadata, blind_sig, inv)
+  sig = Finalize(pk, input_msg, info, blind_sig, inv)
 ~~~
 
 In the remainder of this section, we specify the Blind, BlindSign, and Finalize
@@ -166,10 +166,10 @@ they satisfy a particular criteria. In particular, each RSA modulus for a key pa
 MUST be the product of two safe primes p and q. A safe prime p is a prime number
 such that p = 2q + 1, where q is also a prime number.
 
-A signing key pair is a tuple (skS, pkS), where each element is as follows:
+A signing key pair is a tuple (sk, pk), where each element is as follows:
 
-- skS = (p, q, phi, d), where phi = (p - 1)(q - 1)
-- pkS = (n, e), where n = p * q and d * e == 1 mod phi.
+- sk = (p, q, phi, d), where phi = (p - 1)(q - 1)
+- pk = (n, e), where n = p * q and d * e == 1 mod phi.
 
 The procedure for generating a key pair satisfying this requirement is below.
 
@@ -180,7 +180,7 @@ Inputs:
 - bits, length in bits of the RSA modulus, a multiple of 2
 
 Outputs:
-- (skS, pkS), a signing key pair
+- (sk, pk), a signing key pair
 
 Steps:
 1. p = SafePrime(bits / 2)
@@ -189,9 +189,9 @@ Steps:
 4. phi = (p - 1) * (q - 1)
 5. e = 65537
 6. d = inverse_mod(e, phi)
-7. skS = (p, q, phi, d)
-8. pkS = (p * q, e)
-9. output (skS, pkS)
+7. sk = (p, q, phi, d)
+8. pk = (p * q, e)
+9. output (sk, pk)
 ~~~
 
 The procedure for generating a safe prime, denoted SafePrime, is below.
@@ -231,21 +231,21 @@ for invalid inputs. However, this error cannot occur based on how RSAVP1 is invo
 so this error is not included in the list of errors for Blind.
 
 ~~~
-Blind(pkS, msg, metadata)
+Blind(pk, msg, info)
 
 Parameters:
-- kLen, the length in bytes of the RSA modulus n
+- modulus_len, the length in bytes of the RSA modulus n
 - Hash, the hash function used to hash the message
 - MGF, the mask generation function
-- sLen, the length in bytes of the salt
+- salt_len, the length in bytes of the salt
 
 Inputs:
-- pkS, server public key (n, e)
+- pk, public key (n, e)
 - msg, message to be signed, a byte string
-- metadata, public metadata, a byte string
+- info, public metadata, a byte string
 
 Outputs:
-- blinded_msg, a byte string of length kLen
+- blinded_msg, a byte string of length modulus_len
 - inv, an integer
 
 Errors:
@@ -255,9 +255,9 @@ Errors:
 - "invalid input": Raised when the message is not co-prime with n.
 
 Steps:
-1. msg_prime = concat("msg", int_to_bytes(len(metadata), 4), metadata, msg)
+1. msg_prime = concat("msg", int_to_bytes(len(info), 4), info, msg)
 2. encoded_msg = EMSA-PSS-ENCODE(msg_prime, bit_len(n))
-   with Hash, MGF, and sLen as defined in the parameters
+   with Hash, MGF, and salt_len as defined in the parameters
 3. If EMSA-PSS-ENCODE raises an error, raise the error and stop
 4. m = bytes_to_int(encoded_msg)
 5. c = is_coprime(m, n)
@@ -267,15 +267,15 @@ Steps:
 8. inv = inverse_mod(r, n)
 9. If inverse_mod fails, raise an "blinding error" error
    and stop
-10. pkM = AugmentPublicKey(pkS, metadata)
-11. x = RSAVP1(pkM, r)
+10. pk_derived = DerivePublicKey(info)
+11. x = RSAVP1(pk_derived, r)
 12. z = m * x mod n
-13. blinded_msg = int_to_bytes(z, kLen)
+13. blinded_msg = int_to_bytes(z, modulus_len)
 14. output blinded_msg, inv
 ~~~
 
 The blinding factor r MUST be randomly chosen from a uniform distribution.
-This is typically done via rejection sampling. The function AugmentPublicKey
+This is typically done via rejection sampling. The function DerivePublicKey
 is defined in {{augment-public-key}}.
 
 ## BlindSign
@@ -285,19 +285,19 @@ blinded message input and returns the output encoded as a byte string.
 RSASP1 is as defined in {{Section 5.2.1 of !RFC8017}}.
 
 ~~~
-BlindSign(skS, blinded_msg, metadata)
+BlindSign(sk, blinded_msg, info)
 
 Parameters:
-- kLen, the length in bytes of the RSA modulus n
+- modulus_len, the length in bytes of the RSA modulus n
 
 Inputs:
-- skS, server private key
+- sk, private key
 - blinded_msg, encoded and blinded message to be signed, a
   byte string
-- metadata, public metadata, a byte string
+- info, public metadata, a byte string
 
 Outputs:
-- blind_sig, a byte string of length kLen
+- blind_sig, a byte string of length modulus_len
 
 Errors:
 - "signing failure": Raised when the signing operation fails
@@ -306,13 +306,12 @@ Errors:
 
 Steps:
 1. m = bytes_to_int(blinded_msg)
-2. skM = AugmentPrivateKey(skS, pkS, metadata)
-3. pkM = AugmentPublicKey(pkS, metadata)
-4. s = RSASP1(skM, m)
-5. m' = RSAVP1(pkM, s)
-6. If m != m', raise "signing failure" and stop
-7. blind_sig = int_to_bytes(s, kLen)
-8. output blind_sig
+2. sk_derived, pk_derived = DeriveKeyPair(sk, info)
+3. s = RSASP1(sk_derived, m)
+4. m' = RSAVP1(pk_derived, s)
+5. If m != m', raise "signing failure" and stop
+6. blind_sig = int_to_bytes(s, modulus_len)
+7. output blind_sig
 ~~~
 
 ## Finalize
@@ -323,24 +322,24 @@ upon success. Note that this function will internally hash the input message
 as is done in Blind.
 
 ~~~
-Finalize(pkS, msg, metadata, blind_sig, inv)
+Finalize(pk, msg, info, blind_sig, inv)
 
 Parameters:
-- kLen, the length in bytes of the RSA modulus n
+- modulus_len, the length in bytes of the RSA modulus n
 - Hash, the hash function used to hash the message
 - MGF, the mask generation function
-- sLen, the length in bytes of the salt
+- salt_len, the length in bytes of the salt
 
 Inputs:
-- pkS, server public key (n, e)
+- pk, public key (n, e)
 - msg, message to be signed, a byte string
-- metadata, public metadata, a byte string
+- info, public metadata, a byte string
 - blind_sig, signed and blinded element, a byte string of
-  length kLen
+  length modulus_len
 - inv, inverse of the blind, an integer
 
 Outputs:
-- sig, a byte string of length kLen
+- sig, a byte string of length modulus_len
 
 Errors:
 - "invalid signature": Raised when the signature is invalid
@@ -348,33 +347,33 @@ Errors:
   have the expected length.
 
 Steps:
-1. If len(blind_sig) != kLen, raise "unexpected input size" and stop
+1. If len(blind_sig) != modulus_len, raise "unexpected input size" and stop
 2. z = bytes_to_int(blind_sig)
 3. s = z * inv mod n
-4. sig = int_to_bytes(s, kLen)
-5. msg_prime = concat("msg", int_to_bytes(len(metadata), 4), metadata, msg)
-6. pkM = AugmentPublicKey(pkS, metadata)
-7. result = RSASSA-PSS-VERIFY(pkM, msg_prime, sig) with
-   Hash, MGF, and sLen as defined in the parameters
+4. sig = int_to_bytes(s, modulus_len)
+5. msg_prime = concat("msg", int_to_bytes(len(info), 4), info, msg)
+6. pk_derived = DerivePublicKey(pk, info)
+7. result = RSASSA-PSS-VERIFY(pk_derived, msg_prime, sig) with
+   Hash, MGF, and salt_len as defined in the parameters
 8. If result = "valid signature", output sig, else
    raise "invalid signature" and stop
 ~~~
 
-Note that `pkM` can be computed once during `Blind` and then passed to
+Note that `pk_derived` can be computed once during `Blind` and then passed to
 `Finalize` directly, rather than being recomputed again.
 
 ## Verification
 
 As described in {{core-protocol}}, the output of the protocol is the prepared
 message `input_msg` and the signature `sig`. The message that applications
-consume is `msg`, from which `input_msg` is derived, along with metadata `metadata`.
+consume is `msg`, from which `input_msg` is derived, along with metadata `info`.
 Clients verify the signature over `msg` and `info` using the server's public
-key `pkS` as follows:
+key `pk` as follows:
 
-1. Compute `pkM = AugmentPublicKey(pkS, info)`.
-2. Compute `msg_prime = concat("msg", int_to_bytes(len(metadata), 4), metadata, msg)`.
+1. Compute `pk_derived = DerivePublicKey(info)`.
+2. Compute `msg_prime = concat("msg", int_to_bytes(len(info), 4), info, msg)`.
 3. Invoke and output the result of RSASSA-PSS-VERIFY ({{Section 8.1.2 of !RFC8017}})
-   with `(n, e)` as `pkM`, M as `msg_prime`, and `S` as `sig`.
+   with `(n, e)` as `pk_derived`, M as `msg_prime`, and `S` as `sig`.
 
 Verification and the message that applications consume therefore depends on
 which preparation function is used. In particular, if the PrepareIdentity
@@ -383,63 +382,63 @@ In contrast, if the PrepareRandomize function is used, then the application
 message is `slice(input_msg, 32, len(input_msg))`, i.e., the prepared message
 with the random prefix removed.
 
-## Public Key Augmentation {#augment-public-key}
+## Public Key Derivation {#augment-public-key}
 
-The public key augmentation function (AugmentPublicKey) derives a per-metadata public
+The public key derivation function (DerivePublicKey) derives a per-metadata public
 key that is used in the core protocol. The hash function used for HKDF is that which
 is associated with the RSAPBSSA instance and denoted by the `Hash` parameter. Note that
 the input to HKDF is expanded to account for bias in the output distribution.
 
 ~~~
-AugmentPublicKey(pkS, metadata)
+DerivePublicKey(info)
 
 Parameters:
-- kLen, the length in bytes of the RSA modulus n
+- modulus_len, the length in bytes of the RSA modulus n
 - Hash, the hash function used to hash the message
 
 Inputs:
-- pkS, server public key (n, e)
-- metadata, public metadata, a byte string
+- info, public metadata, a byte string
 
 Outputs:
-- pkM, augmented server public key (n, e')
+- pk_derived, metadata-specific public key (n, e')
 
 Steps:
-1. hkdf_input = concat("key", metadata, 0x00)
-2. hkdf_salt = int_to_bytes(n, kLen)
-3. lambda_len = kLen / 2
+1. hkdf_input = concat("key", info, 0x00)
+2. hkdf_salt = int_to_bytes(n, modulus_len)
+3. lambda_len = modulus_len / 2
 4. hkdf_len = lambda_len + 16
 5. expanded_bytes = HKDF(IKM=hkdf_input, salt=hkdf_salt, info="PBRSA", L=hkdf_len)
 6. expanded_bytes[0] &= 0x3F // Clear two-most top bits
 7. expanded_bytes[lambda_len-1] |= 0x01 // Set bottom-most bit
 8. e' = bytes_to_int(slice(expanded_bytes, lambda_len))
-9. output pkM = (n, e * e')
+9. output pk_derived = (n, e')
 ~~~
 
-## Private Key Augmentation {#augment-private-key}
+## Private Key Derivation {#augment-private-key}
 
-The public key augmentation function (AugmentPrivateKey) derives a per-metadata private
+The public key augmentation function (DeriveKeyPair) derives a per-metadata private
 signing key that is used by the server in the core protocol.
 
 ~~~
-AugmentPrivateKey(skS, pkS, metadata)
+DeriveKeyPair(sk, info)
 
 Parameters:
-- kLen, the length in bytes of the RSA modulus n
+- modulus_len, the length in bytes of the RSA modulus n
 - Hash, the hash function used to hash the message
 
 Inputs:
-- skS, server private key (p, q, phi, d)
-- pkS, server public key (n, e)
-- metadata, public metadata, a byte string
+- sk, private key (p, q, phi, d)
+- info, public metadata, a byte string
 
 Outputs:
-- skM, augmented server private key (p, q, phi, d')
+- sk_derived, metadata-specific private key (p, q, phi, d')
+- pk_derived, metadata-specific public key (n, e')
 
 Steps:
-1. (n, e') = AugmentPublicKey(pkS, metadata)
+1. (n, e') = DerivePublicKey(info)
 2. d' = inverse_mod(e', phi)
-3. output pkM = (p, q, phi, d')
+3. sk_derived = (p, q, phi, d')
+4. Output (sk_derived, pk_derived)
 ~~~
 
 # Implementation and Usage Considerations
@@ -467,7 +466,8 @@ exceptional event differently, e.g., by informing the server that the key has be
 The RECOMMENDED method for generating the server signing key pair is as specified in FIPS 186-4
 {{?DSS=DOI.10.6028/NIST.FIPS.186-4}}.
 
-A server signing key MUST NOT be reused for any other protocol beyond RSAPBSSA. Moreover, a
+A server signing key MUST NOT be reused for any other protocol beyond RSAPBSSA. In particular,
+the same signing key MUST NOT be used for both the RSAPBSSA and RSABSSA protocols. Moreover, a
 server signing key MUST NOT be reused for different RSAPBSSA encoding options. That is,
 if a server supports two different encoding options, then it MUST have a distinct key
 pair for each option.
@@ -480,7 +480,7 @@ OID {{!RFC5756}}. It MUST NOT use the rsaEncryption OID {{?RFC5280}}.
 In this section, we define named variants of RSAPBSSA. These variants consider
 different sets of RSASSA-PSS parameters as defined in {{Section 9.1.1 of ?RFC8017}} and explicitly
 specified in {{Section 5 of ?RSABSSA=I-D.irtf-cfrg-rsa-blind-signatures}}. For algorithms unique
-to RSAPBSSA, the choice of hash function specifies the instantation of HKDF in AugmentPublicKey in
+to RSAPBSSA, the choice of hash function specifies the instantation of HKDF in DerivePublicKey in
 {{augment-public-key}}. The different types of Prepare functions are specified in
 {{Section 4.1 of RSABSSA}}.
 
@@ -538,14 +538,14 @@ also apply to RSAPBSSA here. We present additional security considerations speci
 
 An essential component of RSAPBSSA is that the KeyGen algorithm in {{key-generation}} generates a RSA
 modulus that is the product of two strong primes. This is essential to ensure that the resulting outputs
-of AugmentPublicKey in {{augment-public-key}} does cause errors in AugmentPrivateKey in {{augment-private-key}}.
-We note that an error in AugmentPrivateKey would incur if the output of AugmentPublicKey does not have an
+of DerivePublicKey in {{augment-public-key}} does cause errors in DeriveKeyPair in {{augment-private-key}}.
+We note that an error in DeriveKeyPair would incur if the output of DerivePublicKey does not have an
 inverse modulo phi. By choosing the RSA modulus as the product of two strong primes, we guarantee the output of
-AugmentPublicKey will never incur errors in AugmentPrivateKey.
+DerivePublicKey will never incur errors in DeriveKeyPair.
 
 It is integral that one uses the KeyGen algorithm for RSAPBSSA instead of the standard RSA key generation algorithms
 (such as those used in {{RSABSSA}}). If one uses standard RSA key generation, there are no guarantees provided
-for the success of the AugmentPrivateKey function and, thus, being able to correctly sign messages for certain choices
+for the success of the DeriveKeyPair function and, thus, being able to correctly sign messages for certain choices
 of public metadata.
 
 ## Domain Separation for Public Key Augmentation
@@ -554,13 +554,13 @@ The purpose of domain separation is to guarantee that the security analysis of a
 even if multiple instances of the protocol or multiple hash functions in a single instance of the protocol
 are instantiated based on one underlying hash function.
 
-The AugmentPublicKey in {{augment-public-key}} of this document already provide domain separation by using the RSA modulus
+The DerivePublicKey in {{augment-public-key}} of this document already provide domain separation by using the RSA modulus
 as input to the underlying HKDF as the info argument. As each instance of RSAPBSSA will have a different RSA modulus, this
 effectively ensures that the outputs of the underlying hash functions for multiple instances will be different
 even for the same input.
 
 Additionally, the hash function invocation used for computing the message digest is domain separated from the hash function
-invocation used for augmenting the public key in AugmentPublicKey. This domain separation is done by prepending the inputs
+invocation used for augmenting the public key in DerivePublicKey. This domain separation is done by prepending the inputs
 to each hash function with a unique domain separation tag.
 
 ## Choosing Public Metadata
@@ -579,8 +579,8 @@ should be contextualized to an application's user population size.
 ## Denial of Service
 
 RSAPBSSA is suspectible to Denial of Service (DoS) attacks due to the flexibility of choosing public metadata used in
-AugmentPublicKey in {{augment-public-key}}. In particular, an attacker can pick public metadata such that
-the output of AugmentPublicKey is very large, leading to more computational cost when verifying signatures.
+DerivePublicKey in {{augment-public-key}}. In particular, an attacker can pick public metadata such that
+the output of DerivePublicKey is very large, leading to more computational cost when verifying signatures.
 Thus, if attackers can force verification with metadata of their choosing, DoS attacks are possible.
 
 For applications where the values of potential public metadata choices are fixed ahead of time, it is possible

--- a/draft-amjad-cfrg-partially-blind-rsa.md
+++ b/draft-amjad-cfrg-partially-blind-rsa.md
@@ -414,10 +414,11 @@ Steps:
 9. output pk_derived = (n, e')
 ~~~
 
-## Private Key Derivation {#augment-private-key}
+## Key Pair Derivation {#augment-private-key}
 
-The public key augmentation function (DeriveKeyPair) derives a per-metadata private
-signing key that is used by the server in the core protocol.
+The key pair derivation function (DeriveKeyPair) derives a pair of private
+and public keys specific to a metadata value that are used by the server
+in the core protocol.
 
 ~~~
 DeriveKeyPair(sk, info)


### PR DESCRIPTION
Also, use "info" consistently as the public metadata parameter name to align the POPRF terminology from draft-irtf-cfrg-voprf.