### PR TITLE
EMSA-PSS-ENCODE using bit_len(n) - 1

### DIFF
--- a/draft-amjad-cfrg-partially-blind-rsa.md
+++ b/draft-amjad-cfrg-partially-blind-rsa.md
@@ -258,7 +258,7 @@ Errors:
 
 Steps:
 1. msg_prime = concat("msg", int_to_bytes(len(info), 4), info, msg)
-2. encoded_msg = EMSA-PSS-ENCODE(msg_prime, bit_len(n))
+2. encoded_msg = EMSA-PSS-ENCODE(msg_prime, bit_len(n) - 1)
    with Hash, MGF, and salt_len as defined in the parameters
 3. If EMSA-PSS-ENCODE raises an error, raise the error and stop
 4. m = bytes_to_int(encoded_msg)


### PR DESCRIPTION
EMSA-PSS-ENCODE using bit_len(n) - 1

This ensures that the verification as defined in https://www.rfc-editor.org/rfc/rfc8017#section-8.1.2 matches, in case a verifier is using a standard   RSASSA-PSS-VERIFY implementation.