### PR TITLE
Update to FIPS 186-5

### DIFF
--- a/draft-amjad-cfrg-partially-blind-rsa.md
+++ b/draft-amjad-cfrg-partially-blind-rsa.md
@@ -67,7 +67,8 @@ that have large or arbitrary amounts of metadata.
 This document specifies a variant of RSABSSA that supports public metadata, denoted
 RSAPBSSA (RSA Partially Blind Signature with Appendix). Similar to RSABSSA in
 {{RSABSSA}}, RSAPBSSSA is defined in such a way that the resulting (unblinded)
-signature can be verified with a standard RSA-PSS library.
+signature can be verified with a standard RSA-PSS library that does not impose a
+range limit on the public exponent.
 
 # Conventions and Definitions
 
@@ -469,7 +470,7 @@ exceptional event differently, e.g., by informing the server that the key has be
 ## Signing Key Generation and Usage {#cert-oid}
 
 The RECOMMENDED method for generating the server signing key pair is as specified in FIPS 186-4
-{{?DSS=DOI.10.6028/NIST.FIPS.186-4}}.
+{{?DSS=DOI.10.6028/NIST.FIPS.186-5}}.
 
 A server signing key MUST NOT be reused for any other protocol beyond RSAPBSSA. In particular,
 the same signing key MUST NOT be used for both the RSAPBSSA and RSABSSA protocols. Moreover, a


### PR DESCRIPTION
FIPS 186-4 will soon be withdrawn, so we should refer to 186-5.

Additionally, we should be more precise with our reference to 'standard' RSA-PSS libraries, as SYMCRYPT doesn't support exponents larger than 64 bits:
https://github.com/microsoft/SymCrypt/blob/b4f07a34bdb970e8690dc13a98fb9fb77edc0f50/inc/symcrypt.h#L6705