### PR TITLE
Take mod n of z during computation

### DIFF
--- a/draft-amjad-cfrg-partially-blind-rsa.md
+++ b/draft-amjad-cfrg-partially-blind-rsa.md
@@ -350,7 +350,7 @@ Errors:
 
 Steps:
 1. If len(blind_sig) != modulus_len, raise "unexpected input size" and stop
-2. z = bytes_to_int(blind_sig)
+2. z = bytes_to_int(blind_sig) mod n
 3. s = z * inv mod n
 4. sig = int_to_bytes(s, modulus_len)
 5. msg_prime = concat("msg", int_to_bytes(len(info), 4), info, msg)


### PR DESCRIPTION
This may make the implementation of `z * inv mod n` on the next line less error prone.